### PR TITLE
fix: don't show blank speed when speed is 10 or 100

### DIFF
--- a/html/js/hud.js
+++ b/html/js/hud.js
@@ -55,10 +55,10 @@ $(function() {
 			}
 			
 			// Vehicle speed display
-			if(CalcSpeed > 100) {
+			if(CalcSpeed >= 100) {
 				var tmpSpeed = Math.floor(CalcSpeed) + '';
 				speedText = '<span class="int1">' + tmpSpeed.substr(0, 1) + '</span><span class="int2">' + tmpSpeed.substr(1, 1) + '</span><span class="int3">' + tmpSpeed.substr(2, 1) + '</span>';
-			} else if(CalcSpeed > 10 && CalcSpeed < 100) {
+			} else if(CalcSpeed >= 10 && CalcSpeed < 100) {
 				var tmpSpeed = Math.floor(CalcSpeed) + '';
 				speedText = '<span class="gray int1">0</span><span class="int2">' + tmpSpeed.substr(0, 1) + '</span><span class="int3">' + tmpSpeed.substr(1, 1) + '</span>';
 			} else if(CalcSpeed > 0 && CalcSpeed < 10) {


### PR DESCRIPTION
Basically, whenever the speed was 10 or 100, it would show as blank because the if statements didn't know how to handle it due to it not comparing properly.